### PR TITLE
use egis to grab rockweed data

### DIFF
--- a/reports/sections/crithab/crithab_preprocessing.R
+++ b/reports/sections/crithab/crithab_preprocessing.R
@@ -40,7 +40,6 @@ leatherback_rr <- list("title" = " Leatherback Sea Turtle draft critical habitat
                        "data_sf" = leatherback_sf,
                        "attribute" = "NONE",
                        "metadata" = list("contact" = email_format("info@dfo-mpo.gc.ca"),
-                                         "url" = lang_list("<https://www.narwc.org/sightings-database.html>"),
                                          "accessedOnStr" = list("en" ="February 25 2021", "fr" = "25 février 2021") ,
                                          "accessDate" = as.Date("2021-02-25"),
                                          "securityLevel" = noneList,

--- a/reports/sections/rockweed/rockweed_preprocessing.R
+++ b/reports/sections/rockweed/rockweed_preprocessing.R
@@ -26,6 +26,7 @@ rockweed_rr <- list("title" = "Satellite-based Maps of Intertidal Vegetation and
                     "data_sf" = final_rockweed_sf,
                     "attribute" = "status",
                     "metadata" = list("contact" = email_format("Gordana.Lazin@dfo-mpo.gc.ca"), 
+                                      "url" = lang_list("<https://gisd.dfo-mpo.gc.ca/portal/home/item.html?id=cbf26467bce84abc972a04e88581a030>"),
                                       "accessedOnStr" = list("en" ="July 28 2022", 
                                                              "fr" = "28 juillet 2022") ,
                                       "accessDate" = as.Date("2022-07-28"),

--- a/reports/sections/rockweed/rockweed_preprocessing.R
+++ b/reports/sections/rockweed/rockweed_preprocessing.R
@@ -10,25 +10,25 @@ loadResult <- load_rdata(c("CommonData", "rockweed_rr"), regionStr)
 
 # ---------------------ROCKWEED------------------------------
 # Rockweed
-rockweed_sf <- sf::st_read(file.path(fileLoadPath, "NaturalResources/Species/Rockweed/MAR_rockweed_presence_validated.shp"), stringsAsFactors = FALSE)
-rockweed_sf <- sf::st_transform(rockweed_sf, 4326) # Project to WGS84
+rwServer <- "https://gisd.dfo-mpo.gc.ca/arcgis/rest/services/FGP/MARboundary_Rockweed_Presence_validated/MapServer/0/"
+rwBbox <- sf::st_bbox(sf::st_transform(region_sf, 3857))
+rockweed_sf <- esri2sf::esri2sf(rwServer, bbox = rwBbox, progress = TRUE)
+
 rockweed_sf <- sf::st_make_valid(rockweed_sf)
 # set status column
 rockweed_sf$status = ""
 rockweed_sf$status[which(rockweed_sf$RWP==1)] = "Present"
 rockweed_sf$status[which(rockweed_sf$RWP==2)] = "Likely Present"
 rockweed_sf$status[which(rockweed_sf$RWP==5)] = "Unknown"
-rockweed_sf$status[which(rockweed_sf$RWP==0)] = "Not Present"
-rockweed_sf <- sf::st_crop(rockweed_sf, region_sf)
-
+final_rockweed_sf <- dplyr::select(rockweed_sf, c("status"))
 
 rockweed_rr <- list("title" = "Satellite-based Maps of Intertidal Vegetation and Rockweed presence polygons",
-                    "data_sf" = rockweed_sf,
+                    "data_sf" = final_rockweed_sf,
                     "attribute" = "status",
                     "metadata" = list("contact" = email_format("Gordana.Lazin@dfo-mpo.gc.ca"), 
-                                      "accessedOnStr" = list("en" ="February 17 2021", 
-                                                             "fr" = "17 février 2021") ,
-                                      "accessDate" = as.Date("2021-02-17"),
+                                      "accessedOnStr" = list("en" ="July 28 2022", 
+                                                             "fr" = "28 juillet 2022") ,
+                                      "accessDate" = as.Date("2022-07-28"),
                                       "searchYears" = "2020",
                                       "securityLevel" = noneList,
                                       "qualityTier" = mediumQuality,


### PR DESCRIPTION
Update rockweed preprocessing to grab data from the EGIS server instead of file on the IN drive. 