### PR TITLE
Crop to intersect

### DIFF
--- a/reports/R/intersectFunctions.R
+++ b/reports/R/intersectFunctions.R
@@ -76,8 +76,8 @@ master_intersect <- function(data_sf, mapDataList, getRegion=FALSE, ...) {
     }
 
     mapData <- sf::st_crop(data_sf, mapArea)
-    studyData <- sf::st_crop(mapData, mapDataList$studyArea)
-
+    studyData <- sf::st_intersection(mapData, sf::st_geometry(mapDataList$studyArea))
+    
     # if there is no intersect with the box, set return to NULL
     if (nrow(mapData) == 0) {mapData <- NULL}
 

--- a/reports/sections/ilts/ilts_en.Rmd
+++ b/reports/sections/ilts/ilts_en.Rmd
@@ -39,8 +39,6 @@ iltsClipped <- master_intersect(ilts_rr$data_sf, mapDataList)
 introResult <- !is.null(iltsClipped$studyData)
 summaryIntroTable <- add_row_to_intro_summary(summaryIntroTable, name="[ILTS](#ilts-section)", result=introResult)
 
-
-
 tableList <- create_sar_tables(iltsClipped$studyData, listed_species)
 iltsAllTable <- tableList$allSpecies
 iltsSarTable <- tableList$sarData

--- a/reports/sections/sarsearch/sarsearch_en.rmd
+++ b/reports/sections/sarsearch/sarsearch_en.rmd
@@ -59,13 +59,14 @@ outputList <- master_intersect(sarsearch_rr$data_sf, mapDataList, getRegion = TR
 introResult <- !is.null(outputList$studyData)
 summaryIntroTable <- add_row_to_intro_summary(summaryIntroTable, name="[SAR search DMapp](#sarsearch-section)", result=introResult)
 
-sarsearchTable <- sf::st_drop_geometry(outputList$studyData)
-sarsearchTable <- if (!is.null(outputList$studyData)) {
-    dplyr::select(sarsearchTable, c(species_name, year, name, source, record_type, notes))
+sarsearchTable <- NULL
+if (!is.null(outputList$studyData)) {
+  sarsearchTable <- sf::st_drop_geometry(outputList$studyData)
+  dplyr::select(sarsearchTable, c(species_name, year, name, source, record_type, notes))
   names(sarsearchTable) <- c("Species Name", "Year", "Location Name", "Source", "Geometry Type", "Notes")  
-sarsearchTable[is.na(sarsearchTable)] <- ""
-row.names(sarsearchTable) <- NULL  
-      }
+  sarsearchTable[is.na(sarsearchTable)] <- ""
+  row.names(sarsearchTable) <- NULL  
+}
 
 ```
 


### PR DESCRIPTION
swap out the `st_crop()` call in master intersect for `st_intersection()`. This allows the report to use the actual geometry of the study area instead of assuming that it is a rectangle.  St_crop is still used to generate the region and map data as these are cropped by rectangular data (Any plot in the report WILL be a rectangle)